### PR TITLE
Harden WS auth reconnect UX and Windows CLI/CWD handling

### DIFF
--- a/lib/agent-runtime.js
+++ b/lib/agent-runtime.js
@@ -17,7 +17,33 @@ function createAgentRuntime(deps) {
     getRuntimeSessionId,
   } = deps;
 
+  function wrapWindowsCommandShim(command, args) {
+    if (process.platform !== 'win32') {
+      return { command, args };
+    }
+    const cmd = String(command || '').trim();
+    if (!cmd || !/\.(cmd|bat)$/i.test(cmd)) {
+      return { command, args };
+    }
+    return {
+      command: processEnv.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', cmd, ...args],
+    };
+  }
+
   function buildClaudeSpawnSpec(session, options = {}) {
+    const normalizeClaudeModelForCli = (rawModel) => {
+      const raw = String(rawModel || '').trim();
+      if (!raw) return '';
+      // cc-web internally may use bracketed aliases like "claude-opus-4-6[1m]".
+      // Claude CLI expects the real model id without this UI suffix.
+      return raw.replace(/\[1m\]\s*$/i, '');
+    };
+    const configuredMaxOutput = Number.parseInt(String(processEnv.CC_WEB_CLAUDE_MAX_OUTPUT_TOKENS || '').trim(), 10);
+    const safeMaxOutput = Number.isFinite(configuredMaxOutput) && configuredMaxOutput > 0
+      ? configuredMaxOutput
+      : 32768;
+
     const hasAttachments = Array.isArray(options.attachments) && options.attachments.length > 0;
     const args = ['-p', '--output-format', 'stream-json', '--verbose'];
     if (hasAttachments) args.push('--input-format', 'stream-json');
@@ -37,8 +63,17 @@ function createAgentRuntime(deps) {
       args.push('--resume', session.claudeSessionId);
     }
     if (session.model) {
-      args.push('--model', session.model);
+      const normalizedModel = normalizeClaudeModelForCli(session.model);
+      if (normalizedModel) {
+        args.push('--model', normalizedModel);
+      }
     }
+    args.push('--settings', JSON.stringify({
+      CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(safeMaxOutput),
+      env: {
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(safeMaxOutput),
+      },
+    }));
 
     const env = { ...processEnv };
     delete env.CLAUDECODE;
@@ -48,15 +83,20 @@ function createAgentRuntime(deps) {
       if (k.startsWith('ANTHROPIC_')) delete env[k];
     }
 
+    // Many OpenAI-compatible Anthropic bridges cap output tokens at 32768.
+    // Force a safe default for cc-web runs to avoid inherited global 128000 settings.
+    env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = String(safeMaxOutput);
+
     const modelCfg = loadModelConfig();
     if (modelCfg.mode === 'custom' && modelCfg.activeTemplate) {
       const tpl = (modelCfg.templates || []).find((t) => t.name === modelCfg.activeTemplate);
       if (tpl) applyCustomTemplateToSettings(tpl);
     }
 
+    const wrapped = wrapWindowsCommandShim(CLAUDE_PATH, args);
     return {
-      command: CLAUDE_PATH,
-      args,
+      command: wrapped.command,
+      args: wrapped.args,
       env,
       cwd: session.cwd || processEnv.HOME || processEnv.USERPROFILE || process.cwd(),
       parser: 'claude',
@@ -135,9 +175,10 @@ function createAgentRuntime(deps) {
       delete env.OPENAI_BASE_URL;
     }
 
+    const wrapped = wrapWindowsCommandShim(CODEX_PATH, args);
     return {
-      command: CODEX_PATH,
-      args,
+      command: wrapped.command,
+      args: wrapped.args,
       env,
       cwd: session.cwd || processEnv.HOME || processEnv.USERPROFILE || process.cwd(),
       parser: 'codex',

--- a/public/app.js
+++ b/public/app.js
@@ -102,6 +102,7 @@
   let currentSessionRunning = false;
   let skipDeleteConfirm = localStorage.getItem('cc-web-skip-delete-confirm') === '1';
   let pendingInitialSessionLoad = false;
+  let wsReconnectNoticeShown = false;
 
   // --- DOM ---
   const $ = (sel) => document.querySelector(sel);
@@ -1104,38 +1105,46 @@
   const PREVIEW_LANGS = new Set(['html', 'svg']);
   const _previewCodeMap = new Map();
   let _previewCodeId = 0;
+  const markedLib = (typeof window.marked !== 'undefined') ? window.marked : null;
+  const hljsLib = (typeof window.hljs !== 'undefined') ? window.hljs : null;
 
-  const renderer = new marked.Renderer();
-  renderer.code = function (code, language) {
-    const lang = (language || 'plaintext').toLowerCase();
-    let highlighted;
-    try {
-      if (hljs.getLanguage(lang)) {
-        highlighted = hljs.highlight(code, { language: lang }).value;
-      } else {
-        highlighted = hljs.highlightAuto(code).value;
+  if (markedLib && typeof markedLib.Renderer === 'function') {
+    const renderer = new markedLib.Renderer();
+    renderer.code = function (code, language) {
+      const lang = (language || 'plaintext').toLowerCase();
+      let highlighted;
+      try {
+        if (hljsLib && typeof hljsLib.getLanguage === 'function' && hljsLib.getLanguage(lang)) {
+          highlighted = hljsLib.highlight(code, { language: lang }).value;
+        } else if (hljsLib && typeof hljsLib.highlightAuto === 'function') {
+          highlighted = hljsLib.highlightAuto(code).value;
+        } else {
+          highlighted = escapeHtml(code);
+        }
+      } catch {
+        highlighted = escapeHtml(code);
       }
-    } catch {
-      highlighted = escapeHtml(code);
-    }
-    const canPreview = PREVIEW_LANGS.has(lang);
-    const previewBtn = canPreview
-      ? `<button class="code-preview-btn" onclick="ccTogglePreview(this)">Preview</button>`
-      : '';
-    const previewPane = canPreview
-      ? `<div class="code-preview-pane"><iframe class="code-preview-iframe" sandbox="allow-scripts" loading="lazy"></iframe></div>`
-      : '';
-    const cid = canPreview ? (++_previewCodeId) : 0;
-    if (canPreview) _previewCodeMap.set(cid, code);
-    return `<div class="code-block-wrapper${canPreview ? ' has-preview' : ''}"${canPreview ? ` data-cid="${cid}"` : ''}>
+      const canPreview = PREVIEW_LANGS.has(lang);
+      const previewBtn = canPreview
+        ? `<button class="code-preview-btn" onclick="ccTogglePreview(this)">Preview</button>`
+        : '';
+      const previewPane = canPreview
+        ? `<div class="code-preview-pane"><iframe class="code-preview-iframe" sandbox="allow-scripts" loading="lazy"></iframe></div>`
+        : '';
+      const cid = canPreview ? (++_previewCodeId) : 0;
+      if (canPreview) _previewCodeMap.set(cid, code);
+      return `<div class="code-block-wrapper${canPreview ? ' has-preview' : ''}"${canPreview ? ` data-cid="${cid}"` : ''}>
       <div class="code-block-header">
         <span>${escapeHtml(lang)}</span>
         <div class="code-block-actions">${previewBtn}<button class="code-copy-btn" onclick="ccCopyCode(this)">Copy</button></div>
       </div>
       ${previewPane}<pre><code class="hljs language-${escapeHtml(lang)}">${highlighted}</code></pre>
     </div>`;
-  };
-  marked.setOptions({ renderer, breaks: true, gfm: true });
+    };
+    markedLib.setOptions({ renderer, breaks: true, gfm: true });
+  } else {
+    console.warn('marked library is unavailable; markdown rendering fallback enabled.');
+  }
 
   window.ccCopyCode = function (btn) {
     const wrapper = btn.closest('.code-block-wrapper');
@@ -1172,6 +1181,7 @@
 
     ws.onopen = () => {
       reconnectAttempts = 0;
+      wsReconnectNoticeShown = false;
       if (authToken) send({ type: 'auth', token: authToken });
     };
 
@@ -1183,6 +1193,11 @@
 
     ws.onclose = () => {
       clearSessionLoading();
+      if (isGenerating) finishGenerating();
+      if (!wsReconnectNoticeShown) {
+        appendSystemMessage('连接已断开，正在自动重连…');
+        wsReconnectNoticeShown = true;
+      }
       scheduleReconnect();
     };
     ws.onerror = () => {};
@@ -1571,8 +1586,12 @@
 
   function renderMarkdown(text) {
     if (!text) return '<div class="typing-indicator"><span></span><span></span><span></span></div>';
-    try { return marked.parse(text); }
-    catch { return escapeHtml(text); }
+    try {
+      if (markedLib && typeof markedLib.parse === 'function') {
+        return markedLib.parse(text);
+      }
+    } catch {}
+    return escapeHtml(text).replace(/\n/g, '<br>');
   }
 
   function createMsgElement(role, content, attachments = []) {
@@ -4042,6 +4061,16 @@
     try { localStorage.setItem(RECENT_CWD_KEY, JSON.stringify(list)); } catch {}
   }
 
+  function normalizeCwdInput(value) {
+    const raw = String(value || '').trim();
+    if (!raw) return null;
+    // Fix mixed shortcut input like "~/D:\\project\\repo" on Windows.
+    if (/^~[\\/]+[a-zA-Z]:[\\/]/.test(raw)) {
+      return raw.replace(/^~[\\/]+/, '');
+    }
+    return raw;
+  }
+
   // --- New Session Modal ---
   let _onCwdSuggestions = null;
 
@@ -4064,7 +4093,7 @@
             <div>
               <label class="modal-field-label" for="ns-cwd-input">工作目录</label>
               <div class="modal-field-row">
-                <input type="text" id="ns-cwd-input" class="modal-text-input" placeholder="例如 /home/user/project" list="ns-cwd-list" autocomplete="off">
+                <input type="text" id="ns-cwd-input" class="modal-text-input" placeholder="例如 D:\\project\\repo 或 /home/user/project" list="ns-cwd-list" autocomplete="off">
                 <datalist id="ns-cwd-list"></datalist>
               </div>
             </div>
@@ -4117,7 +4146,7 @@
     overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
 
     overlay.querySelector('#ns-create-btn').addEventListener('click', () => {
-      const cwd = cwdInput.value.trim() || null;
+      const cwd = normalizeCwdInput(cwdInput.value);
       close();
       if (cwd) saveRecentCwd(cwd);
       send({ type: 'new_session', cwd, agent: targetAgent, mode: currentMode });
@@ -4340,7 +4369,26 @@
 
   // Register Service Worker for mobile push notifications
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('/sw.js').catch(() => {});
+    const swVersion = '20260325';
+    navigator.serviceWorker.getRegistrations()
+      .then((registrations) => Promise.all(registrations.map((registration) => {
+        const scriptUrl = registration.active?.scriptURL
+          || registration.waiting?.scriptURL
+          || registration.installing?.scriptURL
+          || '';
+        try {
+          const parsed = new URL(scriptUrl);
+          // Clean up legacy root registration created by old cc-web bundles.
+          if (parsed.origin === location.origin && parsed.pathname === '/sw.js') {
+            return registration.unregister();
+          }
+        } catch {}
+        return null;
+      })))
+      .catch(() => {})
+      .finally(() => {
+        navigator.serviceWorker.register(`sw.js?v=${swVersion}`).catch(() => {});
+      });
   }
 
   // Restore remembered password

--- a/server.js
+++ b/server.js
@@ -17,8 +17,8 @@ if (fs.existsSync(envPath)) {
 }
 
 const PORT = parseInt(process.env.PORT) || 8002;
-const CLAUDE_PATH = process.env.CLAUDE_PATH || 'claude';
-const CODEX_PATH = process.env.CODEX_PATH || 'codex';
+const CLAUDE_PATH = process.env.CLAUDE_PATH || (process.platform === 'win32' ? 'claude.cmd' : 'claude');
+const CODEX_PATH = process.env.CODEX_PATH || (process.platform === 'win32' ? 'codex.cmd' : 'codex');
 const CONFIG_DIR = process.env.CC_WEB_CONFIG_DIR || path.join(__dirname, 'config');
 const SESSIONS_DIR = process.env.CC_WEB_SESSIONS_DIR || path.join(__dirname, 'sessions');
 const PUBLIC_DIR = process.env.CC_WEB_PUBLIC_DIR || path.join(__dirname, 'public');
@@ -754,6 +754,25 @@ function wsSend(ws, data) {
 
 function sanitizeId(id) {
   return String(id).replace(/[^a-zA-Z0-9\-]/g, '');
+}
+
+function normalizeSessionCwd(cwdValue) {
+  if (cwdValue == null) return null;
+  let cwd = String(cwdValue).trim();
+  if (!cwd) return null;
+
+  // Windows users sometimes paste paths like "~/D:\\project\\repo".
+  // Normalize to a valid drive path to avoid false permission/cwd errors.
+  if (/^~[\\/]+[a-zA-Z]:[\\/]/.test(cwd)) {
+    cwd = cwd.replace(/^~[\\/]+/, '');
+  } else if (cwd === '~' || cwd === '~/') {
+    cwd = process.env.HOME || process.env.USERPROFILE || process.cwd();
+  } else if (/^~[\\/]/.test(cwd)) {
+    const home = process.env.HOME || process.env.USERPROFILE || process.cwd();
+    cwd = path.join(home, cwd.replace(/^~[\\/]+/, ''));
+  }
+
+  return cwd;
 }
 
 function sessionPath(id) {
@@ -2170,7 +2189,7 @@ function handleSlashCommand(ws, text, sessionId, fallbackAgent) {
 
 // === Session Handlers ===
 function handleNewSession(ws, msg) {
-  const cwd = (msg && msg.cwd) ? String(msg.cwd) : null;
+  const cwd = normalizeSessionCwd(msg?.cwd);
   const agent = normalizeAgent(msg?.agent);
   const requestedMode = ['default', 'plan', 'yolo'].includes(msg?.mode) ? msg.mode : 'yolo';
   const resolvedCwd = cwd || (agent === 'claude' ? (process.env.HOME || process.env.USERPROFILE || process.cwd()) : null);
@@ -2508,6 +2527,10 @@ function handleMessage(ws, msg, options = {}) {
 	    };
 	  }
   normalizeSession(session);
+  const normalizedSessionCwd = normalizeSessionCwd(session.cwd);
+  if (normalizedSessionCwd !== session.cwd) {
+    session.cwd = normalizedSessionCwd;
+  }
 
   if (normalizedText.startsWith('/') && resolvedAttachments.length > 0) {
     return wsSend(ws, { type: 'error', message: '命令消息暂不支持同时附带图片。请先发送图片说明，再单独使用 /model 或 /mode。' });
@@ -2626,11 +2649,34 @@ function handleMessage(ws, msg, options = {}) {
     return wsSend(ws, { type: 'error', message: formatRuntimeError(agent, err.message, { exitCode: null, signal: null }) });
   }
 
+  let launchErrorHandled = false;
+  const handleSpawnLaunchError = (err) => {
+    if (launchErrorHandled) return;
+    launchErrorHandled = true;
+    const agent = getSessionAgent(session);
+    const raw = err && err.message ? err.message : String(err || 'unknown spawn error');
+    plog('ERROR', 'process_spawn_runtime_error', {
+      sessionId: currentSessionId.slice(0, 8),
+      agent,
+      command: spawnSpec.command,
+      error: raw,
+    });
+    activeProcesses.delete(currentSessionId);
+    cleanRunDir(currentSessionId);
+    wsSend(ws, { type: 'error', message: formatRuntimeError(agent, raw, { exitCode: null, signal: null }) });
+    wsSend(ws, { type: 'done', sessionId: currentSessionId });
+    sendSessionList(ws);
+  };
+  proc.once('error', handleSpawnLaunchError);
+
   fs.closeSync(inputFd);
   fs.closeSync(outputFd);
   fs.closeSync(errorFd);
 
-  fs.writeFileSync(path.join(dir, 'pid'), String(proc.pid));
+  const pidValue = Number(proc.pid);
+  if (Number.isFinite(pidValue) && pidValue > 0) {
+    fs.writeFileSync(path.join(dir, 'pid'), String(pidValue));
+  }
   proc.unref(); // Process survives Node.js exit
 
   plog('INFO', 'process_spawn', {
@@ -2645,6 +2691,7 @@ function handleMessage(ws, msg, options = {}) {
 
   // Fast exit detection (while Node.js is running)
   proc.on('exit', (code, signal) => {
+    if (launchErrorHandled) return;
     plog('INFO', 'process_exit_event', {
       sessionId: currentSessionId.slice(0, 8),
       pid: proc.pid,


### PR DESCRIPTION
﻿## Summary
- harden Windows runtime command launching by wrapping `.cmd/.bat` tools through `cmd /d /s /c`, and defaulting Windows CLI paths to `claude.cmd`/`codex.cmd`
- normalize session CWD input (including mixed forms like `~/D:\project\repo`) on both new-session creation and existing-session message send path
- improve spawn error handling to surface runtime launch failures cleanly without PID write crashes
- improve frontend resilience for websocket reconnect and markdown/highlight fallback handling
- normalize new-session CWD modal input and refresh service worker registration strategy

## Why
- fixes false "permission denied" style failures on Windows caused by CLI shim execution differences
- prevents invalid mixed CWD formats from being passed into runtime `-C`/`cwd`
- improves behavior during transient websocket disconnect/reconnect and static-asset refreshes

## Validation
- `node --check server.js`
- `node --check lib/agent-runtime.js`
- `node --check public/app.js`
- local runtime probe: `spawnSync('codex')` returns `EPERM` in this environment, while `cmd /c codex.cmd --version` succeeds (`codex-cli 0.116.0`)

## Notes
- upstream repo is read-only for this account, so this PR is opened from fork `CLASSLU/cc-web`
